### PR TITLE
Add eslint and prettier

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,7 +4,7 @@
     "rules": {
         "prettier/prettier": "warn",
         "no-unused-vars": "warn",
-        "arrow-body-style": "warn",
+        "arrow-body-style": "off",
         "no-console": "off",
         "func-names": "off",
         "object-shorthand": "off",
@@ -13,7 +13,7 @@
         "no-underscore-dangle": "off",
         "no-param-reassign": "off",
         "no-alert": "off",
-        "no-use-before-define": "warn",
+        "no-use-before-define": "off",
         "no-continue": "warn",
         "prefer-destructuring": [
             "error",

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,0 +1,40 @@
+{
+    "extends": ["airbnb", "prettier"],
+    "plugins": ["prettier"],
+    "rules": {
+        "prettier/prettier": "warn",
+        "no-unused-vars": "warn",
+        "arrow-body-style": "warn",
+        "no-console": "off",
+        "func-names": "off",
+        "object-shorthand": "off",
+        "class-methods-use-this": "off",
+        "no-plusplus": "off",
+        "no-underscore-dangle": "off",
+        "no-param-reassign": "off",
+        "no-alert": "off",
+        "no-use-before-define": "warn",
+        "no-continue": "warn",
+        "prefer-destructuring": [
+            "error",
+            { "AssignmentExpression": { "array": false } }
+        ],
+        "import/no-extraneous-dependencies": [
+            "error",
+            {
+                "devDependencies": ["**/webpack.*.js"]
+            }
+        ]
+    },
+    "overrides": [
+        {
+            "files": ["**/*.test.js", "**/*.test.jsx"],
+            "env": {
+                "jest": true
+            }
+        }
+    ],
+    "env": {
+        "browser": true
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,33 +1,44 @@
 {
-  "name": "game-jam",
-  "version": "1.0.0",
-  "description": "edutainment based game focused around animal trivia",
-  "main": "index.js",
-  "scripts": {
-    "test": "jest",
-    "watchTests": "jest --watch /src/*test.js",
-    "build": "webpack",
-    "serve": "npx webpack serve --hot-only"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/bappyasif/edutainment_game_based_on_animal_trivia.git"
-  },
-  "author": "ab",
-  "license": "ISC",
-  "bugs": {
-    "url": "https://github.com/bappyasif/edutainment_game_based_on_animal_trivia/issues"
-  },
-  "homepage": "https://github.com/bappyasif/edutainment_game_based_on_animal_trivia#readme",
-  "devDependencies": {
-    "@babel/preset-env": "^7.14.8",
-    "jest": "^27.0.6",
-    "web-dev-server": "^3.0.22",
-    "webpack": "^5.45.1",
-    "webpack-cli": "^4.7.2",
-    "webpack-dev-server": "^3.11.2"
-  },
-  "dependencies": {
-    "gh-pages": "^3.2.3"
-  }
+    "name": "game-jam",
+    "version": "1.0.0",
+    "description": "edutainment based game focused around animal trivia",
+    "main": "index.js",
+    "scripts": {
+        "test": "jest",
+        "watchTests": "jest --watch /src/*test.js",
+        "build": "webpack",
+        "serve": "npx webpack serve --hot-only"
+    },
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/bappyasif/edutainment_game_based_on_animal_trivia.git"
+    },
+    "author": "ab",
+    "license": "ISC",
+    "bugs": {
+        "url": "https://github.com/bappyasif/edutainment_game_based_on_animal_trivia/issues"
+    },
+    "homepage": "https://github.com/bappyasif/edutainment_game_based_on_animal_trivia#readme",
+    "prettier": {
+        "trailingComma": "es5",
+        "tabWidth": 4,
+        "semi": false,
+        "singleQuote": true
+    },
+    "devDependencies": {
+        "@babel/preset-env": "^7.14.8",
+        "eslint": "^7.31.0",
+        "eslint-config-airbnb": "^18.2.1",
+        "eslint-config-prettier": "^8.3.0",
+        "eslint-plugin-prettier": "^3.4.0",
+        "jest": "^27.0.6",
+        "prettier": "^2.3.2",
+        "web-dev-server": "^3.0.22",
+        "webpack": "^5.45.1",
+        "webpack-cli": "^4.7.2",
+        "webpack-dev-server": "^3.11.2"
+    },
+    "dependencies": {
+        "gh-pages": "^3.2.3"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "prettier": {
         "trailingComma": "es5",
         "tabWidth": 4,
-        "semi": false,
+        "semi": true,
         "singleQuote": true
     },
     "devDependencies": {


### PR DESCRIPTION
Once merged, it may throw a lot of errors. Let's try to adhere to the rules as much as possible and let's avoid turning off some rules just to get rid of the errors unless it's necessary. ESLint will also tell us about the dependency cycle. If we don't want to deal with this atm, turn off `import/no-cycle` rule.

And if you haven't already, install the ESLint extension on VSC.